### PR TITLE
Add docker-compose.override.yml and yarn.lock to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 .tmp
 node_modules/
 build/
+yarn.lock
+docker-compose.override.yml


### PR DESCRIPTION
I'm currently using `docker-compose.override` to share my ssh keys for deploy by docker.
And we not need a `yarn.lock`